### PR TITLE
ci: bump deprecated GitHub Actions for Pages deploy

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -43,7 +43,7 @@ jobs:
         cache: 'npm'
     - name: Install npm dependencies (TailwindCSS CLI)
       run: npm ci
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: /tmp/hugo_cache_runner/
         key: ${{ runner.os }}-hugomod-${{ hashFiles('**/go.mod') }}
@@ -51,7 +51,7 @@ jobs:
           ${{ runner.os }}-hugomod-
     - name: Setup Pages
       id: pages
-      uses: actions/configure-pages@v3
+      uses: actions/configure-pages@v5
     - name: Build with Hugo
       env:
         HUGO_ENVIRONMENT: production
@@ -61,7 +61,7 @@ jobs:
     - name: Generate Pagefind search index
       run: npx pagefind --site "public"
     - name: Upload artifact
-      uses: actions/upload-pages-artifact@v2
+      uses: actions/upload-pages-artifact@v3
       with:
         path: ./public
 
@@ -76,4 +76,4 @@ jobs:
     steps:
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v2
+      uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

`actions/upload-pages-artifact@v2` が内部で利用している `actions/upload-artifact@v3` が GitHub Actions 側で deprecated 扱いになり、PR #7 / #8 マージ後の `Deploy website to GitHub Pages` ワークフローが自動失敗していた。

各 Action のメジャーバージョンを最新へ更新:
- `actions/cache@v3` → v4
- `actions/configure-pages@v3` → v5
- `actions/upload-pages-artifact@v2` → v3
- `actions/deploy-pages@v2` → v4

## Test plan

- [ ] このPRのマージ後、`Deploy website to GitHub Pages` workflow が success
- [ ] 本番(GitHub Pages) に直近の content 変更が反映される

🤖 Generated with [Claude Code](https://claude.com/claude-code)