### PR TITLE
content(en): translate recent posts and project pages to English

### DIFF
--- a/content/en/post/ahs2026/index.md
+++ b/content/en/post/ahs2026/index.md
@@ -1,6 +1,6 @@
 ---
-title: 🏝️ AHs 2026 を Local Arrangement Chair として運営しました！
-summary: 沖縄で開催された Augmented Humans 2026 にて、デモ会場の設営・会場デザイン・ロゴデザイン等を担当しました。
+title: 🏝️ Served as Local Arrangement Chair for AHs 2026!
+summary: At Augmented Humans 2026 in Okinawa, I led the demo-venue setup, on-site design, and logo / graphic design.
 date: 2026-03-19
 authors:
   - admin
@@ -12,21 +12,16 @@ image:
 include_content: true
 ---
 
-2026年3月16〜19日に沖縄で開催された **Augmented Humans International Conference 2026 (AHs 2026)** に、**Local Arrangement Chair** として運営に携わりました。
+I served as **Local Arrangement Chair** for the **Augmented Humans International Conference 2026 (AHs 2026)**, held in Okinawa from March 16–19, 2026.
 
-担当したのは、
+My responsibilities were focused on the parts that don't usually take the spotlight but quietly shape the on-site experience, including:
 
-- **デモ会場の設営** — 出展者一人一人と必要機材・電源・スペースを詰め、当日は会場でひたすら動き回っていました
-- **会場デザイン** — 来場者の動線、サイネージ、装飾等
-- **ロゴ / グラフィックデザイン** — 学会のビジュアルアイデンティティ周り
+- **Demo venue setup** — coordinating equipment, power, and floor space with each exhibitor, and running around the venue throughout the conference
+- **On-site design** — visitor flow, signage, and decoration
+- **Logo / graphic design** — the visual identity of the conference
 
-など、表に出にくいけれど学会の体験を支える部分を中心に。
+What struck me most after going through it was that a conference is built on a long stretch of **quiet, unglamorous, behind-the-scenes work**. Every desk arrangement, every cable run, every printed sign carries someone's judgment and effort behind it. As an attendee or speaker, I had taken all of that for granted — but now I have a renewed respect for the organizers who have done this in the past, making it look effortless.
 
-実際にやってみて感じたのは、学会というのは **準備期間の地道で目に見えない仕事の積み重ね** で成り立っているということでした。
-登壇者・参加者として参加していた頃には全く意識していなかった、机の配置一つ・配線一本・標識一枚の裏側にも、誰かの判断と手間がある。
-それを当たり前のように動かしている過去のオーガナイザの方々に、改めて頭が下がる思いでした。
+And there is no way one person could have pulled this off alone. I'm sincerely grateful to the faculty members and staff who ran it with me, to the vendors who responded to last-minute requests, and to every participant who came up to me on-site to say "this was fun." There were so many things I only learned by doing them — both the hard parts and the rewarding ones.
 
-そして、これだけのことを一人で回すのは到底無理で、共に運営してくださった先生方・スタッフの皆さま、無理な依頼にも応えてくれた業者の方々、そして当日「楽しかった」と声をかけてくださった参加者の皆さまに、心から感謝しています。
-やってみないと分からない大変さも、やってみないと分からない学びも、たくさんありました。
-
-今回 AHs に来てくださったすべての方、そして陰で支えてくださったすべての方に、本当にありがとうございました 🙏
+To everyone who came to AHs, and to everyone who supported it from behind the scenes, thank you so much 🙏

--- a/content/en/post/sbintuitions/index.md
+++ b/content/en/post/sbintuitions/index.md
@@ -1,6 +1,6 @@
 ---
-title: 👤 SB Intuitions の Research Scientist になりました！
-summary: 2026年4月より、SB Intuitions に Research Scientist として参画しました。
+title: 👤 Joined SB Intuitions as a Research Scientist!
+summary: As of April 2026, I joined SB Intuitions as a Research Scientist.
 date: 2026-04-01
 authors:
   - admin
@@ -10,13 +10,11 @@ image:
   caption: 
 ---
 
-2026年4月1日付で、**SB Intuitions** に **Research Scientist** として参画しました。
+As of April 1, 2026, I have joined **SB Intuitions** as a **Research Scientist**.
 
-直前まで在籍していた **ソニーCSL** での1年半は、本当にかけがえのない時間でした。
-これまで自分が積み上げてきた身体・力覚インタフェースの軸を保ちつつ、AIとの統合や、人間の認知・自己観に踏み込む研究へと、少し違う角度から挑戦させてもらえた経験は、自分の研究観そのものを大きく広げてくれました。
-受け入れてくださった笠原さんをはじめ、Cybernetic Humanity Lab の皆さま、そしてOISTで一緒に過ごしてくださった皆さまには、本当に感謝しています。
+The 1.5 years I spent at **Sony CSL** right before this move were truly invaluable. While keeping my long-standing focus on body and haptic interfaces, I was given the chance to step into research that integrates with AI and probes human cognition and self-perception — an experience that meaningfully widened my view of what research can be.
+I'm deeply grateful to Shun Kasahara for taking me in, to everyone in the Cybernetic Humanity Lab, and to the OIST community I shared time with.
 
-SB Intuitions では、これまでの身体・HCI のバックグラウンドを活かしつつ、基盤モデルやAIと人間との関わりという新しい領域にも踏み込んでいきたいと考えています。
-身体性・物理性に閉じない地平から、これまでとは違う角度で「人と機械の融合」を追求していきます。
+At SB Intuitions, I want to bring my background in body / HCI to bear on a new domain: foundation models and the relationship between humans and AI. I aim to pursue "the integration of humans and machines" from an angle that isn't bounded by physicality alone.
 
-これからもどうぞよろしくお願いいたします 🙏
+Thanks as always for your support going forward 🙏

--- a/content/en/project/flyingFingertip/index.md
+++ b/content/en/project/flyingFingertip/index.md
@@ -1,6 +1,6 @@
 ---
 title: Flying at Your Fingertips
-summary: 指先の力入力で空を飛ぶ ― AHs 2026発表
+summary: Fly through 3D space with fingertip force input — published at AHs 2026
 tags:
 - research
 date: "2026-03-16T00:00:00Z"
@@ -14,28 +14,28 @@ image:
   focal_point: Smart
 ---
 
-# 関連論文
-本プロジェクトは、Augmented Humans 2026 (AHs 2026, 沖縄) で発表されました。
+# Related Publication
+This project was presented at the Augmented Humans International Conference 2026 (AHs 2026) in Okinawa.
 
 > **[Flying at Your Fingertips: Input Mapping Strategies for Fingertip Force-Based 3D Locomotion](https://doi.org/10.1145/3795011.3795047)**
 > Shun Kondoh, Takeru Hashimoto, Yutaro Hirao, Takuji Narumi
 > *The Augmented Humans International Conference 2026 (AHs 2026), Okinawa, Japan, March 16–19, 2026*
 > [📄 PDF](paper.pdf)
 
-# 概要
-3次元空間を自在に移動する操作は、VR内のロコモーション、ドローン遠隔操作、ロボット遠隔操縦など、ますます多くの応用で重要になりつつあります。一方、ジョイスティック操作は習熟に時間がかかり、全身ジェスチャでの操作は疲労や空間制約を伴います。
+# Overview
+Free 3D navigation is becoming increasingly important across applications such as VR locomotion, drone teleoperation, and remote robotics. Yet today's options each have downsides: joystick-based control takes time to master, while body-motion interfaces tend to be tiring and demand space.
 
-本研究では、指先で加える「力」を入力として用いる **Fingertip Force Input** に着目し、変位の少ない小さな動作で高次元の操作を実現する道を探ります。
+This project explores **fingertip force input** as an alternative — a way to drive high-dimensional control with very small physical motion.
 
-# YUBI：指先力入力による 4DoF ロコモーション
-両親指で加える力の方向と大きさを 3次元並進＋ヨー回転 (4DoF) の入力に変換するシステム **YUBI** を構築し、トンネル通過課題を用いた評価実験を行いました。
+# YUBI: 4-DoF Locomotion via Fingertip Force
+We built **YUBI**, a system that maps the direction and magnitude of forces applied by both thumbs into 3D translation + yaw (4-DoF) locomotion, and evaluated it through a tunnel-traversal task.
 
-5種類の入力マッピング戦略を比較した結果:
+We compared five different mapping strategies for force-to-motion. The findings:
 
-- ジョイスティックの変位ベース・マッピングをそのまま力入力デバイスに移植すると、軸間の干渉によって性能が大きく低下する
-- 提案する **「ハンドル状」 の冗長マッピング** ― 両親指の 6DoF 力入力を統合する設計 ― は、ゲームパッドと同等の操作精度を達成しつつ、**直感性 (intuitiveness)** と **身体性 (embodiment)** の評価でゲームパッドを上回りました
+- Naively replicating the displacement-based mapping of a joystick on a force-input device significantly degrades performance, due to cross-axis interference.
+- Our proposed **"wheel-like" redundant mapping** — which integrates 6-DoF force input from both thumbs — matched the precision of a gamepad while scoring higher on **intuitiveness** and **embodiment**.
 
-# 設計指針
-力入力インタフェースは、変位ベースのコントローラの操作体系をそのまま模倣するのではなく、**冗長性** と **実世界のメタファ** を活用することで、精度・直感性・身体的負荷のバランスをうまく取ることができます。本研究の知見は、ドローン操縦インタフェースや VR ロコモーション、テレプレゼンス・ロボティクスなど、身体内蔵の制御感覚を活かす次世代ヒューマンインタフェース設計への手がかりを提供します。
+# Design Implications
+Force-input interfaces should not simply emulate the control schemes of displacement-based controllers. Leveraging **redundancy** and **real-world metaphors** instead is what allows precision, intuitiveness, and physical comfort to coexist. These findings inform the design of next-generation human interfaces that exploit our body's intrinsic sense of control — drone control, VR locomotion, and tele-robotics among them.
 
-{{<figure src="featured.png" id="teaser" caption="左: 指先力入力デバイス YUBI / 右: トンネル通過評価課題">}}
+{{<figure src="featured.png" id="teaser" caption="Left: the fingertip force input device YUBI. Right: the tunnel-traversal evaluation task.">}}

--- a/content/en/project/hapticAvatar/index.md
+++ b/content/en/project/hapticAvatar/index.md
@@ -1,11 +1,10 @@
 ---
 title: Haptic Avatar
-summary: 身体の「質感」がアバタに応じて変わる ― ISMAR 2025発表
+summary: A body whose physical "feel" changes with the avatar — published at ISMAR 2025
 tags:
 - research
 date: "2025-09-14T00:00:00Z"
 
-# プロジェクトの外部URL（プロジェクト詳細ページの代わりに使用）
 external_link: ""
 featured: true
 draft: false
@@ -13,38 +12,32 @@ draft: false
 image:
   caption: 
   focal_point: Smart
-
-# スライド（オプション）
-#   このプロジェクトに関連するMarkdownスライドを指定
-#   拡張子なしでスライドデッキのファイル名を入力
-#   例：`slides = "example-slides"`は`content/slides/example-slides.md`を参照
-#   スライドがない場合は`slides = ""`と設定
 ---
 
-# 関連論文
-本プロジェクトの成果は、ISMAR 2025 で発表されました。
+# Related Publication
+This project's outcome was presented at ISMAR 2025.
 
 > **[Move Like an Ammonite: Personalizing Force Feedback for Avatar Embodiment in Virtual Reality](https://doi.org/10.1109/ISMAR67309.2025.00098)**
 > Shun Kondoh, Takeru Hashimoto, Takuji Narumi
 > *2025 IEEE International Symposium on Mixed and Augmented Reality (ISMAR), pp. 899–909*
 
-# コンセプト：力覚アバター
-力覚提示技術の進歩により、物体に触れる感覚や道具を握る感覚などの力覚体験をバーチャルリアリティで表現することが可能になりました。これまで力覚技術は、人間と物理世界との相互作用のシミュレーションに広く用いられてきました。
+# Concept: Haptic Avatar
+Advances in haptic display technology now let us recreate experiences such as touching objects or holding tools inside virtual reality. Until now, haptic technology has been used mostly to simulate the interaction between a human and the physical world.
 
-一方で、VR技術により、自分とは異なる特徴をもつアバターを自身の身体として操作することが可能になりつつあります。アバターの外見だけでなく、固有受容感覚（内部的な身体感覚）まで変化させることで、まったく新しい身体への変容感を生み出すことができるのではないでしょうか？
+In parallel, VR has made it possible to inhabit avatars whose body characteristics differ from our own. By altering not only an avatar's appearance but also the wearer's proprioception (the internal sense of one's body), we can begin to evoke the feeling of transforming into an entirely new body.
 
-私たちの目標は、人間の物理的な身体の限界を超えた体験を作り出すことです。
+Our goal is to create experiences that go beyond the physical limits of the human body.
 
-# 身体運動再構成 ― 「アンモナイトのように動く」
-ISMAR 2025 で発表した本研究では、ユーザがアンモナイトのように人間とは大きく異なる体型のアバターに変身したときに、その身体らしい運動感覚を生み出す力覚フィードバックの設計を行いました。
+# Body Movement Reconstruction — "Move Like an Ammonite"
+In our ISMAR 2025 paper, we designed force feedback that produces motion sensations matching an avatar whose form differs sharply from the human body — like an ammonite.
 
-実験では、人間の身体構造から徐々に離れていく **4種類のアバター** （通常の人型 → ロボット型 → 異形型 → アンモナイト型）を用意し、それぞれの身体性に応じた力覚フィードバックを設計しました。
-{{<figure src="4avatars.png" id="4avatars" caption="実験で用いた4つのアバター。人間の身体構造から徐々に離れていく順に並んでいる。">}}
+In the experiment, we prepared **four avatars** whose body structures gradually depart from a typical human form (standard human → robotic → non-human → ammonite), and designed force feedback tailored to the embodiment of each.
+{{<figure src="4avatars.png" id="4avatars" caption="The four avatars used in our experiment, ordered from human-like to ammonite-like.">}}
 
-ユーザーの動きに戦略的なタイミングで力覚を介入させることで、外部から力を加えられているのではなく「自身の身体の物理特性が変わった」という感覚を引き起こします。私たちはこの身体感覚と運動感覚の関係の変化を **身体運動再構成（Body Movement Reconstruction）** と呼んでいます。実装には、物体の静的特性を力情報として表現するインピーダンス制御を応用しました。
+By injecting force feedback at strategically chosen moments during a user's movement, we evoke the perception that the user's *own* body has changed its physical properties — rather than that an external force is being applied. We call this change in the relationship between body sensation and movement **Body Movement Reconstruction**. Internally, this is implemented by reusing impedance control, which represents the static properties of objects as force information.
 
-さらに本論文では、各ユーザにとって最適な没入体験となるよう、ベイズ最適化により力覚パラメータを個別にチューニングする手法（Personalized Force Feedback）を提案しました。これにより、人とは異なる身体への所有感（sense of body ownership）をより強く生起させることができます。
+Building on this, the paper proposes **Personalized Force Feedback**: a method that uses Bayesian optimization to tune force feedback parameters per user, so that the embodiment experience converges to each individual's most immersive setting. This makes the **sense of body ownership** of the non-human body markedly stronger.
 {{<figure src="media/img/somatoshift/heavy_light.png" id="heavy_light">}}
 
-# ハードウェア
-使用している身体装着型の力提示装置については、以下のページで紹介しています。
+# Hardware
+The wearable force-feedback device used in this project is introduced on a separate page.


### PR DESCRIPTION
EN page had recently-added content in Japanese (mirrored from JA as placeholders). Translates the four most-visible files to English. Pre-existing JA content (post/sonycsl など) は今回触っていません。